### PR TITLE
correct guidance for completions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,8 @@ Follow the instructions for creating the `enuf-completion.bash` file from previo
 
 Then in your `.oh-my-zsh/oh-my-zsh.sh` file find this line
 
-```zsh
-autoload -U compaudit compinit
-```
-
-Add the following lines right after it
+Add the following lines at the end of the file. (We add them at the end of the file
+to ensure that `compinit` is running before we attempt to run these instructions).
 
 ```zsh
 autoload -U +X bashcompinit && bashcompinit


### PR DESCRIPTION
While completions have worked for me in zsh for a long time, they recently broke. I'm not sure why. To troublehsoot I created a new user account, install nvm, npm and then installed enuf. Then I followed the instructions to setup for bash (which worked immediately). Then I followed instructions for zsh and when I restarted my session I got a warning

  complete:13: command not found: compdef

I found this Q&A:

https://apple.stackexchange.com/questions/296477/my-command-line-says-complete13-command-not-found-compdef

This led me to discover that compinit must be run before attempting to load bash completions. However when I looked at the oh-my-zsh start up script I could see that compinit was started after the location where I was instructing users to place the completion file.

So I've update the README to state that the additions to the oh-my-zsh file should go at the very end (after compinit) has been started.